### PR TITLE
Correct Typo: UUIDs

### DIFF
--- a/lib/src/bluez_client.dart
+++ b/lib/src/bluez_client.dart
@@ -334,7 +334,7 @@ class BlueZDevice {
 
   /// UUIDs that indicate the available remote services.
   List<BlueZUUID> get uuids => _object
-      .getStringArrayProperty(_deviceInterfaceName, 'UUIDS')
+      .getStringArrayProperty(_deviceInterfaceName, 'UUIDs')
       .map((value) => BlueZUUID(value));
 
   /// True if the device can wake the host from system suspend.


### PR DESCRIPTION
UBUS call was incorrect. UUIDS has been corrected to UUIDs