### PR TITLE
Correct ManufacturerData signature check

### DIFF
--- a/lib/src/bluez_client.dart
+++ b/lib/src/bluez_client.dart
@@ -262,7 +262,7 @@ class BlueZDevice {
     if (value == null) {
       return {};
     }
-    if (value.signature != DBusSignature('a{sv}')) {
+    if (value.signature != DBusSignature('a{qv}')) {
       return {};
     }
     List<int> processValue(DBusVariant value) {


### PR DESCRIPTION
The signature check present was for ServiceData. It has now been corrected for ManufacturerData.