### PR TITLE
Bump dbus dependency, there is a regression in 0.2.0 that broke the O…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dbus: ^0.2.0
+  dbus: ^0.2.2
 
 dev_dependencies:
   pedantic: ^1.9.0


### PR DESCRIPTION
…bjectManager signals.

Fixes https://github.com/canonical/bluez.dart/issues/19