### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Provides a client to connect to [BlueZ](http://www.bluez.org/) - the Linux Bluet
 ```dart
 import 'package:bluez/bluez.dart';
 
-var client = BlueZClient();
+final client = BlueZClient();
 await client.connect();
 
-for (var device in client.devices) {
+for (final device in client.devices) {
   print('Device ${device.address} ${device.alias}');
 }
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ await client.close();
 
 ## Supported platforms
 
-This package shows on pub.dev as supporting all platforms, not just Linux.
-This is because the package doesn't contain any platform specific code that would limit which platforms it can run on.
-It however only makes sense on Linux, as the BlueZ stack is Linux specific, and other platforms have their own Bluetooth stacks.
-You can safely include this package when writing applications that work on multiple platforms, it will fail with an exception when being used if the BlueZ is not present.
-There is an [open issue](https://github.com/dart-lang/pub/issues/2353) requesting the ability to be able to show which platforms a package is intended for.
+This package is designed for use on Linux, as the BlueZ stack is Linux-specific
+(other platforms have their own Bluetooth stacks). You can safely include this
+package when writing applications that work on multiple platforms, but it will
+fail with an exception when being used if the BlueZ is not present.
 
 ## Contributing to bluez.dart
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ await client.close();
 This package is designed for use on Linux, as the BlueZ stack is Linux-specific
 (other platforms have their own Bluetooth stacks). You can safely include this
 package when writing applications that work on multiple platforms, but it will
-fail with an exception when being used if the BlueZ is not present.
+fail with an exception when being used if BlueZ is not present.
 
 ## Contributing to bluez.dart
 


### PR DESCRIPTION
Amend supported platforms section to reflect that pub.dev shows it as being Linux-specific (https://github.com/dart-lang/pub/issues/2353 is fixed). 