### PR TITLE
Fix spelling of 'peripherial' enum to 'peripheral'

### DIFF
--- a/lib/src/bluez_client.dart
+++ b/lib/src/bluez_client.dart
@@ -429,7 +429,7 @@ class BlueZAdvertisingManager {
 
 enum BlueZAdvertisementType {
   broadcast,
-  peripherial,
+  peripheral,
 }
 
 /// BtLE Advertisement instance


### PR DESCRIPTION
Closes #98 