### PR TITLE
Update dbus to 0.7.11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   linux:
 
 dependencies:
-  dbus: ^0.7.8
+  dbus: ^0.7.11
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Dart package dbus in version 0.7.8 exhibits issues that consequently cause problems within the universal_ble package on Linux systems. See discussion at [universal_ble issue 80 ](https://github.com/Navideck/universal_ble/issues/80)